### PR TITLE
Add UIKit include to compile correctly with XCode 6.4 stable

### DIFF
--- a/mapsforge-ios/graphics/IOSCanvas.m
+++ b/mapsforge-ios/graphics/IOSCanvas.m
@@ -14,6 +14,7 @@
  */
 
 #import "IOSCanvas.h"
+#import <UIKit/UIKit.h>
 #import <CoreText/CoreText.h>
 #import "org/mapsforge/core/model/Dimension.h"
 

--- a/mapsforge-ios/graphics/IOSPaint.m
+++ b/mapsforge-ios/graphics/IOSPaint.m
@@ -21,6 +21,7 @@
 
 #import "IOSPrimitiveArray.h"
 
+#import <UIKit/UIKit.h>
 #import <CoreText/CoreText.h>
 
 @implementation IOSPaint

--- a/mapsforge-ios/graphics/IOSPointTextContainer.m
+++ b/mapsforge-ios/graphics/IOSPointTextContainer.m
@@ -22,6 +22,7 @@
 #import "org/mapsforge/core/model/Point.h"
 #import "org/mapsforge/core/graphics/Position.h"
 
+#import <UIKit/UIKit.h>
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreText/CoreText.h>
 


### PR DESCRIPTION
CTFontRef requires UIKit to be required in for some versions of XCode 6. Older versions and also the beta do not require UIKit, but a bug during 6 beta, 6.3 and 6.4 appears to cause a compilation issue.
